### PR TITLE
Fix stop button for individual regenerate

### DIFF
--- a/src/app/results/CreateBox.tsx
+++ b/src/app/results/CreateBox.tsx
@@ -3,19 +3,23 @@
 "use client";
 
 import { IoMdRefresh, IoMdClipboard, IoMdCheckmark } from "react-icons/io";
-import { useRef, useState } from "react";
+import { useState } from "react";
 import { useChat } from "@/context/ChatContext";
 import { platformConfig } from "@/utils/config";
 import { PlatformId } from "@/utils/types";
 import { handleCopy, handleRegenerateSingle } from "./Regenerate";
 import { startStreaming } from "@/app/results/startStreaming";
 
-const CreateBox = ({ type }: { type: PlatformId }) => {
+interface CreateBoxProps {
+  type: PlatformId;
+  globalAbortControllerRef: React.MutableRefObject<AbortController | null>;
+}
+
+const CreateBox = ({ type, globalAbortControllerRef }: CreateBoxProps) => {
   const { responses, isLoading, message, file, setResponses, setIsLoading } =
     useChat();
 
   const [copiedPlatform, setCopiedPlatform] = useState<PlatformId | null>(null);
-  const abortControllerRef = useRef<AbortController | null>(null);
 
   const config = platformConfig.find((p) => p.id === type);
   if (!config) return null;
@@ -59,7 +63,7 @@ const CreateBox = ({ type }: { type: PlatformId }) => {
                 file,
                 setResponses,
                 setIsLoading,
-                abortControllerRef,
+                globalAbortControllerRef,
                 startStreaming
               )
             }

--- a/src/app/results/Regenerate.tsx
+++ b/src/app/results/Regenerate.tsx
@@ -48,7 +48,7 @@ export const handleRegenerateSingle = (
   file: any,
   setResponses: (r: any) => void,
   setIsLoading: (loading: boolean) => void,
-  abortControllerRef: React.MutableRefObject<AbortController | null>,
+  globalAbortControllerRef: React.MutableRefObject<AbortController | null>,
   startStreaming: any
 ) => {
   // Clear response for this platform before regenerating
@@ -57,13 +57,14 @@ export const handleRegenerateSingle = (
     [platformId]: "",
   }));
 
-  abortControllerRef.current = new AbortController();
+  // Use the global abort controller ref so the stop button can abort individual regenerations
+  globalAbortControllerRef.current = new AbortController();
   startStreaming(
     message,
     [platformId],
     file,
     setResponses,
     setIsLoading,
-    abortControllerRef.current.signal
+    globalAbortControllerRef.current.signal
   );
 };

--- a/src/app/results/page.tsx
+++ b/src/app/results/page.tsx
@@ -143,7 +143,7 @@ export default function ResultsPage() {
 
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
           {platforms.map((platformId: PlatformId) => (
-            <CreateBox key={platformId} type={platformId} />
+            <CreateBox key={platformId} type={platformId} globalAbortControllerRef={abortControllerRef} />
           ))}
         </div>
       </div>


### PR DESCRIPTION
Centralize `AbortController` to enable the stop button for individual regenerate operations.

Previously, individual regenerate functions created local `AbortController` instances, preventing the global stop button from aborting them. This change ensures all regenerate operations update and use a single global `AbortController` reference.

---
<a href="https://cursor.com/background-agent?bcId=bc-cfb727c6-ab24-4154-8eae-709189b50682"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cfb727c6-ab24-4154-8eae-709189b50682"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

