### PR TITLE
Fix stop button for individual regenerate

### DIFF
--- a/src/app/results/CreateBox.tsx
+++ b/src/app/results/CreateBox.tsx
@@ -3,19 +3,24 @@
 "use client";
 
 import { IoMdRefresh, IoMdClipboard, IoMdCheckmark } from "react-icons/io";
-import { useRef, useState } from "react";
+import { useState, MutableRefObject } from "react";
 import { useChat } from "@/context/ChatContext";
 import { platformConfig } from "@/utils/config";
 import { PlatformId } from "@/utils/types";
 import { handleCopy, handleRegenerateSingle } from "./Regenerate";
 import { startStreaming } from "@/app/results/startStreaming";
 
-const CreateBox = ({ type }: { type: PlatformId }) => {
+const CreateBox = ({
+  type,
+  abortControllerRef,
+}: {
+  type: PlatformId;
+  abortControllerRef: MutableRefObject<AbortController | null>;
+}) => {
   const { responses, isLoading, message, file, setResponses, setIsLoading } =
     useChat();
 
   const [copiedPlatform, setCopiedPlatform] = useState<PlatformId | null>(null);
-  const abortControllerRef = useRef<AbortController | null>(null);
 
   const config = platformConfig.find((p) => p.id === type);
   if (!config) return null;

--- a/src/app/results/Regenerate.tsx
+++ b/src/app/results/Regenerate.tsx
@@ -1,6 +1,15 @@
 // app/results/Regenerate.ts
 
-import { PlatformId } from "@/utils/types";
+import { PlatformId, ChatContextType, MyFile, Responses } from "@/utils/types";
+import type { MutableRefObject } from "react";
+type StartStreamingFn = (
+  message: string,
+  platforms: PlatformId[],
+  file: MyFile | null,
+  setResponses: ChatContextType["setResponses"],
+  setIsLoading: (loading: boolean) => void,
+  signal: AbortSignal
+) => Promise<void>;
 
 export const handleCopy = (
   text: string | undefined,
@@ -16,14 +25,14 @@ export const handleCopy = (
 export const handleRegenerateAll = (
   message: string | null,
   platforms: PlatformId[],
-  file: any,
-  setResponses: (r: any) => void,
+  file: MyFile | null,
+  setResponses: ChatContextType["setResponses"],
   setIsLoading: (loading: boolean) => void,
-  abortControllerRef: React.MutableRefObject<AbortController | null>,
-  startStreaming: any
+  abortControllerRef: MutableRefObject<AbortController | null>,
+  startStreaming: StartStreamingFn
 ) => {
   // Clear responses for selected platforms before regenerating
-  setResponses((prev: any) => {
+  setResponses((prev: Responses) => {
     const reset = { ...prev };
     platforms.forEach((platform) => {
       reset[platform] = "";
@@ -33,7 +42,7 @@ export const handleRegenerateAll = (
 
   abortControllerRef.current = new AbortController();
   startStreaming(
-    message,
+    message ?? "",
     platforms,
     file,
     setResponses,
@@ -45,21 +54,21 @@ export const handleRegenerateAll = (
 export const handleRegenerateSingle = (
   message: string | null,
   platformId: PlatformId,
-  file: any,
-  setResponses: (r: any) => void,
+  file: MyFile | null,
+  setResponses: ChatContextType["setResponses"],
   setIsLoading: (loading: boolean) => void,
-  abortControllerRef: React.MutableRefObject<AbortController | null>,
-  startStreaming: any
+  abortControllerRef: MutableRefObject<AbortController | null>,
+  startStreaming: StartStreamingFn
 ) => {
   // Clear response for this platform before regenerating
-  setResponses((prev: any) => ({
+  setResponses((prev: Responses) => ({
     ...prev,
     [platformId]: "",
   }));
 
   abortControllerRef.current = new AbortController();
   startStreaming(
-    message,
+    message ?? "",
     [platformId],
     file,
     setResponses,

--- a/src/app/results/page.tsx
+++ b/src/app/results/page.tsx
@@ -143,7 +143,11 @@ export default function ResultsPage() {
 
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
           {platforms.map((platformId: PlatformId) => (
-            <CreateBox key={platformId} type={platformId} />
+            <CreateBox
+              key={platformId}
+              type={platformId}
+              abortControllerRef={abortControllerRef}
+            />
           ))}
         </div>
       </div>


### PR DESCRIPTION
Enable the stop button to cancel individual regenerate functions by sharing a single `AbortController` across all regeneration processes.

The individual regenerate function in `CreateBox` previously created its own `AbortController`, preventing the global stop button from cancelling its fetch. This PR refactors `CreateBox` to accept and use the `abortControllerRef` from `results/page.tsx`, ensuring consistent cancellation for initial fetch, regenerate all, and individual regenerate actions. Type safety was also improved in `Regenerate.tsx` and `route.ts`, and the `OpenAI` client initialization was moved to prevent build-time credential errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-c6dd65a3-4034-4df2-995e-7312e13eda2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c6dd65a3-4034-4df2-995e-7312e13eda2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

