### PR TITLE
Investigate social media api endpoint errors

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -78,7 +78,7 @@ export async function POST(request: NextRequest) {
           }
 
           const llmStream = await openrouter.chat.completions.create({
-            model: "x-ai/grok-4-fast:free",
+            model: "deepseek/deepseek-v3.2-exp",
             messages: messages,
             stream: true,
           });


### PR DESCRIPTION
Update AI model from Grok to DeepSeek due to Grok models being removed from OpenRouter.

OpenRouter discontinued all Grok models, leading to "404 No endpoints found" errors for `x-ai/grok-4-fast:free`. This PR updates the model to `deepseek/deepseek-v3.2-exp` to restore functionality.

---
<a href="https://cursor.com/background-agent?bcId=bc-b4bc0b07-846d-4c41-995d-6a32a53265ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b4bc0b07-846d-4c41-995d-6a32a53265ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

